### PR TITLE
added a code example for setting custom responsive breakpoints

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,16 @@ default breakpoints are::
         'desktop': None,
     }
 
+To overwrite the default breakpoints, include a ``RESPONSIVE_BREAKPOINTS`` 
+dictionary in the project's settings.py file::
+
+    # Name, Max Width (inclusive)
+    RESPONSIVE_BREAKPOINTS = {
+        'phone': 480,
+        'tablet': 767,
+        'desktop': None,
+    }
+
 
 License
 --------------------------------------


### PR DESCRIPTION
Maybe a needless inclusion but comes out of spending 45 minutes wondering why my custom breakpoints weren't triggering when they should be as a result of copy-pasting the code out below the `RESPONSIVE_BREAKPOINTS` header. Maybe it would make sense to just use one dictionary name instead of two?
